### PR TITLE
Sensor: use FlattenableUtils::align

### DIFF
--- a/libs/sensor/Sensor.cpp
+++ b/libs/sensor/Sensor.cpp
@@ -562,7 +562,8 @@ void Sensor::flattenString8(void*& buffer, size_t& size,
     uint32_t len = static_cast<uint32_t>(string8.length());
     FlattenableUtils::write(buffer, size, len);
     memcpy(static_cast<char*>(buffer), string8.string(), len);
-    FlattenableUtils::advance(buffer, size, FlattenableUtils::align<4>(len));
+    FlattenableUtils::advance(buffer, size, len);
+    size -= FlattenableUtils::align<4>(buffer);
 }
 
 bool Sensor::unflattenString8(void const*& buffer, size_t& size, String8& outputString8) {


### PR DESCRIPTION
Since it memsets skipped over memory now.

Bug: 141890807
Test: boot, check buffer is zero'd here
Change-Id: Ieb3cd90215a3ccc1dc43365ecde251a50db08553
(cherry picked from commit d58cf5acb863eddbbeb9982439965e259045940e)
(cherry picked from commit dbd0eecfc7570231d5cbb76678b0358c43ee6d3c)